### PR TITLE
Ignore missing cues

### DIFF
--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -1,7 +1,7 @@
 __author__ = ('David-Elias Künstle, Lennard Schneider, '
               'Konstantin Sering, Marc Weitz')
 __author_email__ = 'konstantin.sering@uni-tuebingen.de'
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 __license__ = 'MIT'
 __description__ = ('Naive discriminative learning implements learning and '
                    'classification models based on the Rescorla-Wagner '
@@ -28,6 +28,6 @@ __doc__ = """
 :version: %s
 :author: %s
 :contact: %s
-:date: 2017-04-02
+:date: 2017-04-11
 :copyright: %s
 """ % (__description__, __version__, __author__, __author_email__, __license__)

--- a/pyndl/activation.py
+++ b/pyndl/activation.py
@@ -70,8 +70,12 @@ def activation(event_list, weights, number_of_threads=1, remove_duplicates=None,
         cues = weights.coords["cues"].values.tolist()
         outcomes = weights.coords["outcomes"].values.tolist()
         cue_map = OrderedDict(((cue, ii) for ii, cue in enumerate(cues)))
-        event_cue_indices_list = (tuple(cue_map[cue] for cue in event_cues if cue in cues)
-                                  for event_cues in event_cues_list)
+        if ignore_missing_cues:
+            event_cue_indices_list = (tuple(cue_map[cue] for cue in event_cues if cue in cues)
+                                      for event_cues in event_cues_list)
+        else:
+            event_cue_indices_list = (tuple(cue_map[cue] for cue in event_cues)
+                                      for event_cues in event_cues_list)
         activations = _activation_matrix(list(event_cue_indices_list), weights.values, number_of_threads)
         return xr.DataArray(activations,
                             coords={

--- a/pyndl/activation.py
+++ b/pyndl/activation.py
@@ -10,7 +10,7 @@ import xarray as xr
 from . import ndl
 
 
-def activation(event_list, weights, number_of_threads=1, remove_duplicates=None, ignore_missing_cues=True):
+def activation(event_list, weights, number_of_threads=1, remove_duplicates=None, ignore_missing_cues=False):
     """
     Estimate activations for given events in event file and cue-outcome weights.
 

--- a/pyndl/activation.py
+++ b/pyndl/activation.py
@@ -10,7 +10,7 @@ import xarray as xr
 from . import ndl
 
 
-def activation(event_list, weights, number_of_threads=1, remove_duplicates=None):
+def activation(event_list, weights, number_of_threads=1, remove_duplicates=None, ignore_missing_cues=True):
     """
     Estimate activations for given events in event file and cue-outcome weights.
 
@@ -32,6 +32,9 @@ def activation(event_list, weights, number_of_threads=1, remove_duplicates=None)
         in the same event; True make cues unique per event; False
         keep multiple instances of the same cue (this is usually not
         preferred!)
+    ignore_missing_cues : {True, False}
+        if True function ignores cues which are in the test dataset but not in
+        the weightmatrix
 
     Returns
     -------
@@ -67,7 +70,7 @@ def activation(event_list, weights, number_of_threads=1, remove_duplicates=None)
         cues = weights.coords["cues"].values.tolist()
         outcomes = weights.coords["outcomes"].values.tolist()
         cue_map = OrderedDict(((cue, ii) for ii, cue in enumerate(cues)))
-        event_cue_indices_list = (tuple(cue_map[cue] for cue in event_cues)
+        event_cue_indices_list = (tuple(cue_map[cue] for cue in event_cues if cue in cues)
                                   for event_cues in event_cues_list)
         activations = _activation_matrix(list(event_cue_indices_list), weights.values, number_of_threads)
         return xr.DataArray(activations,

--- a/pyndl/activation.py
+++ b/pyndl/activation.py
@@ -34,7 +34,8 @@ def activation(event_list, weights, number_of_threads=1, remove_duplicates=None,
         preferred!)
     ignore_missing_cues : {True, False}
         if True function ignores cues which are in the test dataset but not in
-        the weightmatrix
+        the weight matrix
+        if False raises a KeyError for cues which are not in the weight matrix
 
     Returns
     -------

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -68,12 +68,9 @@ def test_ignore_missing_cues():
               (['c1', 'c1'], [])]
     reference_activations = np.array([[1, 1], [0, 1], [1, 0], [0, 1]])
 
-    with pytest.raises(ValueError):
-        activations = activation(events, weights, number_of_threads=1)
-
     with pytest.raises(KeyError):
         activations = activation(events, weights, number_of_threads=1,
-                                 remove_duplicates=True, ignore_missing_cues=False)
+                                 remove_duplicates=True)
 
     activations = activation(events, weights, number_of_threads=1,
                              remove_duplicates=True, ignore_missing_cues=True)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -56,6 +56,30 @@ def test_activation_matrix():
     assert np.allclose(reference_activations, activations_mp)
 
 
+def test_ignore_missing_cues():
+    weights = xr.DataArray(np.array([[0, 1], [1, 0], [0, 0]]),
+                           coords={
+                               'cues': ['c1', 'c2', 'c3']
+                           },
+                           dims=('cues', 'outcomes'))
+    events = [(['c1', 'c2', 'c3'], []),
+              (['c1', 'c3'], []),
+              (['c2', 'c4'], []),
+              (['c1', 'c1'], [])]
+    reference_activations = np.array([[1, 1], [0, 1], [1, 0], [0, 1]])
+
+    with pytest.raises(ValueError):
+        activations = activation(events, weights, number_of_threads=1)
+
+    activations = activation(events, weights, number_of_threads=1,
+                             remove_duplicates=True, ignore_missing_cues=True)
+    activations_mp = activation(events, weights, number_of_threads=3,
+                                remove_duplicates=True, ignore_missing_cues=True)
+
+    assert np.allclose(reference_activations, activations)
+    assert np.allclose(reference_activations, activations_mp)
+
+
 def test_activation_dict():
     weights = defaultdict(lambda: defaultdict(float))
     weights['o1']['c1'] = 0

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -105,6 +105,32 @@ def test_activation_dict():
         assert np.allclose(reference_activations[outcome], activation_list)
 
 
+def test_ignore_missing_cues_dict():
+    weights = defaultdict(lambda: defaultdict(float))
+    weights['o1']['c1'] = 0
+    weights['o1']['c2'] = 1
+    weights['o1']['c3'] = 0
+    weights['o2']['c1'] = 1
+    weights['o2']['c2'] = 0
+    weights['o2']['c3'] = 0
+    events = [(['c1', 'c2', 'c3'], []),
+              (['c1', 'c3'], []),
+              (['c2', 'c4'], []),
+              (['c1', 'c1'], [])]
+    reference_activations = {
+        'o1': [1, 0, 1, 0],
+        'o2': [1, 1, 0, 1]
+    }
+
+    with pytest.raises(ValueError):
+        activations = activation(events, weights, number_of_threads=1)
+
+    activations = activation(events, weights, number_of_threads=1,
+                             remove_duplicates=True, ignore_missing_cues=True)
+    for outcome, activation_list in activations.items():
+        assert np.allclose(reference_activations[outcome], activation_list)
+
+
 @slow
 def test_activation_matrix_large():
     """

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -71,6 +71,10 @@ def test_ignore_missing_cues():
     with pytest.raises(ValueError):
         activations = activation(events, weights, number_of_threads=1)
 
+    with pytest.raises(KeyError):
+        activations = activation(events, weights, number_of_threads=1,
+                                 remove_duplicates=True, ignore_missing_cues=False)
+
     activations = activation(events, weights, number_of_threads=1,
                              remove_duplicates=True, ignore_missing_cues=True)
     activations_mp = activation(events, weights, number_of_threads=3,


### PR DESCRIPTION
Fixes that cues which are in the test dataset but not in the weightmatrix raise a KeyError by checking whether they are in the weightmatrix and adds tests to check for correct behaviour.