### PR TITLE
Force pylint version to avoid non-terminating build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,10 @@ commands =
      coveralls
 
 [testenv:lint]
-deps = pylint
-commands = pylint --rcfile=setup.cfg -j 2 pyndl tests
+deps = pylint==1.6.5  
+commands = pylint [] --rcfile=setup.cfg -j 2 pyndl tests
 ignore_outcome = True
+# pylint 1.7.0 and 1.7.1 don't terminate.
 
 [testenv:checktypes]
 deps = mypy

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,9 @@ commands =
      coveralls
 
 [testenv:lint]
-deps = pylint==1.6.5  
-commands = pylint [] --rcfile=setup.cfg -j 2 pyndl tests
+deps = pylint>=1.7.1
+commands = pylint [] --ignore-patterns='.*\.so' --rcfile=setup.cfg -j 2 pyndl tests
 ignore_outcome = True
-# pylint 1.7.0 and 1.7.1 don't terminate.
 
 [testenv:checktypes]
 deps = mypy


### PR DESCRIPTION
Tox build doesn't stop due to bug in current pylint (1.7.0 and 1.7.1)