### PR TITLE
Usage of pycodestyle instead of pep8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON_VERSION := ''
 PYTHONPATH := .
 VENV := .venv
 PYTEST := env PYTHONPATH=$(PYTHONPATH) PYTEST=1 $(VENV)/bin/py.test
-PEP8 := env PYTHONPATH=$(PYTHONPATH) $(VENV)/bin/pep8 --repeat
+PYCODESTYLE := env PYTHONPATH=$(PYTHONPATH) $(VENV)/bin/pycodestyle --repeat
 PYTHON := env PYTHONPATH=$(PYTHONPATH) $(VENV)/bin/python$(PYTHON_VERSION)
 PIP := $(VENV)/bin/pip
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ If you want to develop ``pyndl`` you should additionally install:
 
 .. code:: bash
 
-   pip3 install --user tox pylint pytest pep8 sphinx
+   pip3 install --user tox pylint pytest pycodestyle sphinx
 
 
 Installing
@@ -117,7 +117,7 @@ For manually checking coding guidelines run:
 
 .. code:: bash
 
-    pep8 pyndl tests
+    pycodestyle pyndl tests
     pylint --ignore-patterns='.*\.so' --rcfile=setup.cfg -j 2 pyndl tests
 
 For more details on which tests run in the continuous testing environment
@@ -169,4 +169,3 @@ ideas on how to build the API and how to efficiently run the Rescorla Wagner
 iterative learning on large text corpora are inspired by the way the ndl2
 package solves this problems. The ndl2 package will be published to github in
 August 2017 and a reference will be placed here.
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 ignore =
 max-line-length = 120
 
@@ -11,4 +11,3 @@ disable=E1101
 
 [aliases]
 test=pytest
-

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py{34,35,36}-test, checkstyle, docs
 usedevelop = True
 deps =
      test: pytest
-     test: -rrequirements.txt
 commands =
      test: py.test []
      test: py.test doc/source/examples.rst

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ ignore_outcome = True
 
 [testenv:docs]
 changedir = doc
+whitelist_externals=/usr/bin/make
 deps =
     sphinx
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py{34,35,36}-test, checkstyle, docs
 usedevelop = True
 deps =
      test: pytest
+     -rrequirements.txt
 commands =
      test: py.test []
      test: py.test doc/source/examples.rst

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py{34,35,36}-test, checkstyle, docs
 usedevelop = True
 deps =
      test: pytest
-     -rrequirements.txt
+     test: -rrequirements.txt
 commands =
      test: py.test []
      test: py.test doc/source/examples.rst

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ commands =
      test: py.test doc/source/examples.rst
 
 [testenv:checkstyle]
-deps = pep8
-commands = pep8 pyndl tests
+deps = pycodestyle
+commands = pycodestyle pyndl tests
 
 [testenv:testcov]
 usedevelop = True


### PR DESCRIPTION
This Pull Request updates the `tox.ini` configuration file.

It changes the style checker from pep8 to [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/) since pep8 is depreciated.