### PR TITLE
removes illegal metadata field resource_type

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,10 +18,6 @@
             "name": "Lennart Schneider"
         }
     ],
-    "resource_type": {
-      "title": "Software",
-      "type": "software"
-    },
     "grants": [
       {
         "funder": {


### PR DESCRIPTION
This PR fixes the zenodo error by removing the "Unknown field name" "resource_type" from `.zenodo.json`
