### PR TITLE
Adds sysinfo() function

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,8 +14,4 @@
 * Step 3
 
 ### System details
-* Operating System:
-* Python Version:
-<!-- run `python --version` for version details -->
-* Installed python packages
-<!-- run `pip freeze` for a list of installed packages -->
+<!-- run `python -c "import pyndl; pyndl.sysinfo()"` and copy the output -->

--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -1,7 +1,13 @@
+import os
+import sys
+import multiprocessing as mp
+from pip._vendor import pkg_resources
+
+
 __author__ = ('David-Elias Künstle, Lennard Schneider, '
               'Konstantin Sering, Marc Weitz')
 __author_email__ = 'konstantin.sering@uni-tuebingen.de'
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 __license__ = 'MIT'
 __description__ = ('Naive discriminative learning implements learning and '
                    'classification models based on the Rescorla-Wagner '
@@ -28,6 +34,45 @@ __doc__ = """
 :version: %s
 :author: %s
 :contact: %s
-:date: 2017-04-18
+:date: 2017-12-27
 :copyright: %s
 """ % (__description__, __version__, __author__, __author_email__, __license__)
+
+def sysinfo():
+    """
+    Prints system the dependency information
+    """
+    pyndl = pkg_resources.working_set.by_key["pyndl"]
+    dependencies = [str(r) for r in pyndl.requires()]
+
+    header = "Pyndl " + __version__ + " Information\n"
+    header += ("=" * (len(header) - 1)) + "\n"
+    header += "\n"
+
+    system,node,kernel,version,machine = os.uname()
+
+    osinfo = "Operating System\n"
+    osinfo += ("-" * (len(osinfo) - 1)) + "\n"
+    osinfo += "OS: " + system + " " + machine + "\n"
+    osinfo += "Kernel: " + kernel + "\n"
+    osinfo += "CPU: " + str(mp.cpu_count()) + "\n"
+    if system == "Linux":
+        names, memory, swap = os.popen("free -m").readlines()
+        ix, total, used, *rest = memory.split()
+        osinfo += "Memory: " + used + "MiB/" + total + "MiB\n"
+        ix, total, used, *rest = swap.split()
+        osinfo += "Swap: " + used + "MiB/" + total + "MiB\n"
+    osinfo += "\n"
+
+    py = "Python\n"
+    py += ("-" * (len(py) - 1)) + "\n"
+    py += "Version: " + sys.version.split()[0] + "\n"
+    py += "\n"
+
+    deps = "Dependencies\n"
+    deps += ("-" * (len(deps) - 1)) + "\n"
+    for dep in dependencies:
+        pkg = __import__(dep)
+        deps += pkg.__name__ + ": " + pkg.__version__ + "\n"
+
+    print(header + osinfo + py + deps)

--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -38,6 +38,7 @@ __doc__ = """
 :copyright: %s
 """ % (__description__, __version__, __author__, __author_email__, __license__)
 
+
 def sysinfo():
     """
     Prints system the dependency information
@@ -49,7 +50,7 @@ def sysinfo():
     header += ("=" * (len(header) - 1)) + "\n"
     header += "\n"
 
-    system,node,kernel,version,machine = os.uname()
+    system, node, kernel, version, machine = os.uname()
 
     osinfo = "Operating System\n"
     osinfo += ("-" * (len(osinfo) - 1)) + "\n"

--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -58,9 +58,11 @@ def sysinfo():
     osinfo += "Kernel: " + kernel + "\n"
     osinfo += "CPU: " + str(mp.cpu_count()) + "\n"
     if system == "Linux":
-        names, memory, swap = os.popen("free -m").readlines()
+        names, *lines = os.popen("free -m").readlines()
+        memory = [line for line in lines if "Mem:" in line][0]
         ix, total, used, *rest = memory.split()
         osinfo += "Memory: " + used + "MiB/" + total + "MiB\n"
+        swap = [line for line in lines if "Swap:" in line][0]
         ix, total, used, *rest = swap.split()
         osinfo += "Swap: " + used + "MiB/" + total + "MiB\n"
     osinfo += "\n"

--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -46,36 +46,34 @@ def sysinfo():
     pyndl = pkg_resources.working_set.by_key["pyndl"]
     dependencies = [str(r) for r in pyndl.requires()]
 
-    header = "Pyndl " + __version__ + " Information\n"
-    header += ("=" * (len(header) - 1)) + "\n"
-    header += "\n"
+    header = ("Pyndl Information\n"
+              "=================\n\n")
 
-    system, node, kernel, version, machine = os.uname()
+    general = ("General Information\n"
+               "-------------------\n"
+               "Python version: {}\n"
+               "Pyndl version: {}\n\n").format(sys.version.split()[0], __version__)
 
-    osinfo = "Operating System\n"
-    osinfo += ("-" * (len(osinfo) - 1)) + "\n"
-    osinfo += "OS: " + system + " " + machine + "\n"
-    osinfo += "Kernel: " + kernel + "\n"
-    osinfo += "CPU: " + str(mp.cpu_count()) + "\n"
-    if system == "Linux":
+    uname = os.uname()
+    osinfo = ("Operating System\n"
+              "----------------\n"
+              "OS: {s.sysname} {s.machine}\n"
+              "Kernel: {s.release}\n"
+              "CPU: {cpu_count}\n").format(s=uname, cpu_count=mp.cpu_count())
+
+    if uname.sysname == "Linux":
         names, *lines = os.popen("free -m").readlines()
-        memory = [line for line in lines if "Mem:" in line][0]
-        ix, total, used, *rest = memory.split()
-        osinfo += "Memory: " + used + "MiB/" + total + "MiB\n"
-        swap = [line for line in lines if "Swap:" in line][0]
-        ix, total, used, *rest = swap.split()
-        osinfo += "Swap: " + used + "MiB/" + total + "MiB\n"
+        for identifier in ["Mem:", "Swap:"]:
+            memory = [line for line in lines if identifier in line][0]
+            ix, total, used, *rest = memory.split()
+            osinfo += "{} {}MiB/{}MiB\n".format(identifier, used, total)
+
     osinfo += "\n"
 
-    py = "Python\n"
-    py += ("-" * (len(py) - 1)) + "\n"
-    py += "Version: " + sys.version.split()[0] + "\n"
-    py += "\n"
+    deps = ("Dependencies\n"
+            "------------\n")
 
-    deps = "Dependencies\n"
-    deps += ("-" * (len(deps) - 1)) + "\n"
-    for dep in dependencies:
-        pkg = __import__(dep)
-        deps += pkg.__name__ + ": " + pkg.__version__ + "\n"
+    deps += "\n".join("{pkg.__name__}: {pkg.__version__}".format(pkg=__import__(dep))
+                      for dep in dependencies)
 
-    print(header + osinfo + py + deps)
+    print(header + general + osinfo + deps)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ xarray
 netCDF4
 numpydoc
 docopt
+pip

--- a/tests/test_pyndl.py
+++ b/tests/test_pyndl.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# pylint: disable=C0111
+
+import sys
+import re
+from io import StringIO
+from contextlib import redirect_stdout
+
+import pyndl
+
+
+def test_sysinfo():
+    out = StringIO()
+    with redirect_stdout(out):
+        pyndl.sysinfo()
+    out = out.getvalue()
+
+    pattern = re.compile("[a-zA-Z0-9_\. ]*\n[\=]*\n+([a-zA-Z0-9_ ]*\n[\-]*\n"
+                         "([a-zA-Z0-9_ ]*: [a-zA-Z0-9_\.\-/ ]*\n+)+)+")
+    assert pattern.match(out)


### PR DESCRIPTION
Fixes #116.

Changes proposed in this pull request:
- Adds a function to get the system information. 
- Adds suggestion to call the `pyndl.sysinfo()` function in the issue template and post the output
- Adds test for `pyndl.sysinfo()`

Example:
```
>>> import pyndl
>>> pyndl.sysinfo()
Pyndl 0.3.4 Information
=======================

Operating System
----------------
OS: Linux x86_64
Kernel: 4.4.0-104-generic
CPU: 4
Memory: 4328MiB/15629MiB
Swap: 0MiB/11863MiB

Python
------
Version: 3.5.4

Dependencies
------------
numpy: 1.13.3
matplotlib: 2.1.1
cython: 0.27.3
pandas: 0.21.1
xarray: 0.10.0
netCDF4: 1.2.7
numpydoc: 0.7.0
docopt: 0.6.2
pip: 9.0.1
```

Do we want the function to print the information or to return a string? 