### PR TITLE
corrects python version in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ setup.py``. For details see below.
 
 Prerequisites
 -------------
-You need python 3.4 or newer and git installed on your machine. We recommend to
+You need python 3.5 or newer and git installed on your machine. We recommend to
 install Minicoda (https://conda.io/miniconda.html) before installing ``pyndl``
 or to create a virtualenv within your personal folder.
 


### PR DESCRIPTION
Fixes #123.

Changes proposed in this pull request:
#123  dropped the support for python 3.4. However, the `README.rst` still said

> You need python 3.4 or newer and git installed on your machine.

This PR fixes the README and changes it to

> You need python 3.5 or newer and git installed on your machine.

This PR should be included in the release of [pyndl 0.3.3](https://github.com/quantling/pyndl/releases/tag/untagged-59418cc93872c235597f).