### PR TITLE
adds easydev to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pandas
 xarray
 netCDF4
 numpydoc
+easydev
 pip


### PR DESCRIPTION
[Read the docs](http://readthedocs.org/) is currently not building our documentation  due to a missing requirement. This PR adds this requirement.
