### PR TITLE
fixes copyright year and reorders authors in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,8 @@
 import os
 # import sys
 import shutil
+import time
+
 import easydev
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -68,7 +70,7 @@ master_doc = 'index'
 pkg = __import__('pyndl')
 project = 'pyndl'
 author =  pkg.__author__
-copyright = '2017 ' + pkg.__author__
+copyright = time.strftime('2017 - %Y ') + pkg.__author__
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pyndl/__init__.py
+++ b/pyndl/__init__.py
@@ -14,8 +14,8 @@ import multiprocessing as mp
 from pip._vendor import pkg_resources
 
 
-__author__ = ('David-Elias Künstle, Lennard Schneider, '
-              'Konstantin Sering, Marc Weitz')
+__author__ = ('Konstantin Sering, Marc Weitz, '
+              'David-Elias Künstle, Lennard Schneider')
 __author_email__ = 'konstantin.sering@uni-tuebingen.de'
 __version__ = '0.4.0'
 __license__ = 'MIT'


### PR DESCRIPTION
* makes the copyright line appearing as "2017 - <current year> ' + package authors
* reorders authors as in zenodo citation in package authors