### PR TITLE
Adds Pyup support

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,18 @@
+# PyUp (https://pyup.io/) configuration file
+#
+# see https://pyup.io/docs/bot/config/ for details
+
+# general
+update: all
+pin: True
+schedule: "every day"
+assignees:
+ - derNarr
+ - Trybnetic
+
+# requirement files
+search: True
+
+# Pull Request handling
+close_prs: True
+label_prs: dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
-cython
-pandas
-xarray
-netCDF4
-pip
+numpy>=1.8.2
+cython>=0.21.1
+pandas>=0.14.1
+xarray>=0.7.2
+netCDF4>=1.3.1
+pip>=9.0.1


### PR DESCRIPTION
[PyUp](https://pyup.io/) is a web service to monitor python dependencies. 

Changes proposed in this pull request:
- adds pyup configuration file
- pins dependency versions to minimal requirements (fixes #90)

