### PR TITLE
changes long description encoding to utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     version=version,
     license='MIT',
     description=description,
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding="utf-8").read(),
     author=author,
     author_email=email,
     url='https://github.com/quantling/pyndl',


### PR DESCRIPTION
To avoid encoding issues by different Locales, encode the README as utf-8 while reading it in in `setup.py`