### PR TITLE
Fix safe writing of files #216

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   include:
     - name: "MacOS"
       os: osx
+      osx_image: xcode10.3  # default xcode9.4 is too old for some dependencies
       language: sh
       script: tox -e nolinux
 

--- a/pyndl/corpus.py
+++ b/pyndl/corpus.py
@@ -13,6 +13,8 @@ import gzip
 import multiprocessing
 import xml.etree.ElementTree
 
+from pyndl import io
+
 __version__ = '0.2.0'
 
 FRAMES_PER_SECOND = 30
@@ -185,12 +187,7 @@ def create_corpus_from_gz(directory, outfile, *, n_threads=1, verbose=False):
               (duration, duration // (60 * 60), duration // 60))
 
     if not_founds:
-        # prevent overwriting files
-        file_name = outfile + ".not_found"
-        nn = 1
-        while not os.path.isfile(file_name):
-            nn += 1
-            file_name = outfile + ".not_found-" + str(nn)
+        file_name = io.safe_write_path(outfile + ".not_found", template='{path}-{counter}')
 
         with open(file_name, "wt") as not_found_file:
             not_found_file.writelines(not_founds)

--- a/pyndl/corpus.py
+++ b/pyndl/corpus.py
@@ -13,7 +13,7 @@ import gzip
 import multiprocessing
 import xml.etree.ElementTree
 
-from pyndl import io
+from . import io
 
 __version__ = '0.2.0'
 

--- a/pyndl/io.py
+++ b/pyndl/io.py
@@ -162,8 +162,8 @@ def safe_write_path(path, template='{path.stem}-{counter}{path.suffix}'):
     Returns the original path if it does not exist or
     an incremented version according to the template.
     
-    The default template creates filenames like
-    path/example.png, path/example-1.png, path/example-2.png, etc.
+    This function with the default template creates filenames like
+    pathname/example.png, pathname/example-1.png, pathname/example-2.png, ...
 
     Parameters
     ----------
@@ -173,7 +173,7 @@ def safe_write_path(path, template='{path.stem}-{counter}{path.suffix}'):
 
     Returns
     -------
-    path: path-like of non-existing filename in the same directory.
+    path: the input path or (if file exists) the path with incremented filename.
     """
     if template.format(path=path, counter=1) == template.format(path=path, counter=2):
         raise ValueError(f"Expects template to change by '{{counter}}', got {template}")


### PR DESCRIPTION
Fixes #216.

Changes proposed in this pull request:
- implement and test utility function to create file name without overwriting existing files
- use this utility to extract missing corpus files without overwriting (fix logic bug).