### PR TITLE
Fix runslow tests

### DIFF
--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -150,9 +150,9 @@ def test_activation_matrix_large():
     def time_test(func, of=""):  # pylint: disable=invalid-name
         def dec_func(*args, **kwargs):
             print("start test '{}'".format(of))
-            start = time.clock()
+            start = time.time()
             res = func(*args, **kwargs)
-            end = time.clock()
+            end = time.time()
             print("finished test '{}'".format(of))
             print("  duration: {:.3f}s".format(end - start))
             print("")
@@ -160,15 +160,15 @@ def test_activation_matrix_large():
         return dec_func
 
     nn = 2000
-    n_cues = 10*nn
+    n_cues = 10 * nn
     n_outcomes = nn
-    n_events = 10*nn
+    n_events = 10 * nn
     n_cues_per_event = 30
-    weight_mat = np.random.rand(n_cues, n_outcomes)
+    weight_mat = np.random.rand(n_outcomes, n_cues)
     cues = ['c'+str(i) for i in range(n_cues)]
     weights = xr.DataArray(weight_mat,
                            coords={'cues': cues},
-                           dims=('cues', 'outcomes'))
+                           dims=('outcomes', 'cues'))
     events = [(np.random.choice(cues, n_cues_per_event), [])
               for i in range(n_events)]  # no generator, we use it twice
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -142,19 +142,21 @@ def test_ignore_missing_cues_dict():
 def test_activation_matrix_large():
     """
     Test with a lot of data. Better run only with at least 12GB free RAM.
-    To get time prints for single and multiprocessing run with pytest ... --capture=no --runslow
+    To get time prints for single and multiprocessing run with pytest ...
+    --capture=no --runslow
+
     """
     print("")
     print("Start setup...")
 
     def time_test(func, of=""):  # pylint: disable=invalid-name
         def dec_func(*args, **kwargs):
-            print("start test '{}'".format(of))
+            print(f"start test '{of}'")
             start = time.time()
             res = func(*args, **kwargs)
             end = time.time()
-            print("finished test '{}'".format(of))
-            print("  duration: {:.3f}s".format(end - start))
+            print(f"finished test '{of}'")
+            print(f"  duration: {end - start:.3f}s")
             print("")
             return res
         return dec_func
@@ -165,12 +167,12 @@ def test_activation_matrix_large():
     n_events = 10 * nn
     n_cues_per_event = 30
     weight_mat = np.random.rand(n_outcomes, n_cues)
-    cues = ['c'+str(i) for i in range(n_cues)]
+    cues = [f'c{ii}' for ii in range(n_cues)]
     weights = xr.DataArray(weight_mat,
                            coords={'cues': cues},
                            dims=('outcomes', 'cues'))
     events = [(np.random.choice(cues, n_cues_per_event), [])
-              for i in range(n_events)]  # no generator, we use it twice
+              for _ in range(n_events)]  # no generator, we use it twice
 
     print("Start test...")
     print("")


### PR DESCRIPTION

Changes proposed in this pull request:
- fixes a runslow test of the activation code

As we don't run the "runslow" tests during continuous integration / automatic testing, we missed that there were small errors in the code