### PR TITLE
link ndl2 github page in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,16 +83,16 @@ and `Marc Weitz <https://github.com/trybnetic>`_.
 
 
 Funding
-=======
-*pyndl* supported by the Alexander von Humboldt Professorship awarded to R.
-Harald Baayen, the ERC advanced Grant (no. 742545), and by the University of
-Tübingen.
+-------
+*pyndl* was partially funded by the Humboldt grant, the ERC advanced grant (no.
+742545) and by the University of Tübingen.
 
-Acknowledgments
-===============
-This package is build as a python replacement for the R `ndl2 package
-<https://github.com/quantling/ndl2>`_. Some
+
+Acknowledgements
+----------------
+This package is build as a python replacement for the R ndl2 package. Some
 ideas on how to build the API and how to efficiently run the Rescorla Wagner
 iterative learning on large text corpora are inspired by the way the ndl2
-package solves this problems.
+package solves this problems. The ndl2 package is available on Github `here
+<https://github.com/quantling/ndl2>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,17 @@ Currently, it is maintained by `Konstantin Sering <https://github.com/derNarr>`_
 and `Marc Weitz <https://github.com/trybnetic>`_.
 
 
+Funding
+=======
+*pyndl* supported by the Alexander von Humboldt Professorship awarded to R.
+Harald Baayen, the ERC advanced Grant (no. 742545), and by the University of
+Tübingen.
+
 Acknowledgments
 ===============
-This research was supported by an ERC advanced Grant (no. 742545) and by the
-Alexander von Humboldt Professorship awarded to R. H. Baayen and by the
-University of Tübingen.
+This package is build as a python replacement for the R `ndl2 package
+<https://github.com/quantling/ndl2>`_. Some
+ideas on how to build the API and how to efficiently run the Rescorla Wagner
+iterative learning on large text corpora are inspired by the way the ndl2
+package solves this problems.
+

--- a/docs/source/benchmark.rst
+++ b/docs/source/benchmark.rst
@@ -89,8 +89,9 @@ the iterative learner of `ndl2`. ``R -f run_ndl.R`` runs the `ndl2` on the same 
 while `ndl` only runs on the smaller files because it is orders of magnitude slower.
 
 
-`ndl` can be installed from CRAN by running ``install.packages('ndl')`` in R, while `ndl2` is just
-available upon request (contact `Konstantin Sering <https://uni-tuebingen.de/fakultaeten/philosophische-fakultaet/fachbereiche/neuphilologie/seminar-fuer-sprachwissenschaft/arbeitsbereiche/quantitative-linguistik/mitarbeiter/'>`_, install with ``R CMD INSTALL ndl2.tar.gz``).
+`ndl` can be installed from CRAN by running ``install.packages('ndl')`` in R,
+while `ndl2` needs to be downloaded from Github first (`ndl2
+<https://github.com/quantling/ndl2>`_, install with ``R CMD INSTALL ndl2.tar.gz``).
 
 Both `ndl` and `ndl2` cannot handle compressed event files right away. For `ndl`, we 
 load the full event file into memory (included in time measurement), while `ndl2` reads an uncompressed event

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -58,14 +58,15 @@ If you are using BibTex you may want to use this example BibTex entry::
 
 Funding
 -------
-*pyndl* was partially funded by the Humboldt grant, the ERC advanced grant (no.
-742545) and by the University of Tübingen.
-
+*pyndl* supported by the Alexander von Humboldt Professorship awarded to R.
+Harald Baayen, the ERC advanced Grant (no. 742545), and by the University of
+Tübingen.
 
 Acknowledgements
 ----------------
-This package is build as a python replacement for the R ndl2 package. Some
+This package is build as a python replacement for the R `ndl2 package
+<https://github.com/quantling/ndl2>`_. Some
 ideas on how to build the API and how to efficiently run the Rescorla Wagner
 iterative learning on large text corpora are inspired by the way the ndl2
-package solves this problems. The ndl2 package is available on Github `here
-<https://github.com/quantling/ndl2>`_.
+package solves this problems.
+

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -58,15 +58,14 @@ If you are using BibTex you may want to use this example BibTex entry::
 
 Funding
 -------
-*pyndl* supported by the Alexander von Humboldt Professorship awarded to R.
-Harald Baayen, the ERC advanced Grant (no. 742545), and by the University of
-Tübingen.
+*pyndl* has been supported by the Alexander von Humboldt Professorship awarded
+to R.  Harald Baayen, the ERC advanced Grant WIDE (no. 742545), and the
+University of Tübingen.
 
 Acknowledgements
 ----------------
-This package is build as a python replacement for the R `ndl2 package
-<https://github.com/quantling/ndl2>`_. Some
-ideas on how to build the API and how to efficiently run the Rescorla Wagner
-iterative learning on large text corpora are inspired by the way the ndl2
-package solves this problems.
+This package is build as a Python replacement for the R `ndl2 package
+<https://github.com/quantling/ndl2>`_. Some ideas on how to build the API and
+how to efficiently run the Rescorla Wagner iterative learning on large text
+corpora are inspired by the ndl2 package.
 

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -67,5 +67,5 @@ Acknowledgements
 This package is build as a python replacement for the R ndl2 package. Some
 ideas on how to build the API and how to efficiently run the Rescorla Wagner
 iterative learning on large text corpora are inspired by the way the ndl2
-package solves this problems. The ndl2 package will be published to github soon
-and a reference will be placed here.
+package solves this problems. The ndl2 package is available on Github `here
+<https://github.com/quantling/ndl2>`_.


### PR DESCRIPTION
ndl2 is now on github, this PR links it in the documentation
